### PR TITLE
feat: add web UI and HTTP gateway

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,39 @@
 # grapevined - a music player service
 </div>
 
+## Web UI & HTTP Gateway
+
+This repo now includes:
+
+- `gateway/` – a small Axum HTTP proxy that forwards JSON commands to the TCP daemon (ports 6990–7000)
+- `web/` – a Next.js 14 (TypeScript) UI that calls `/api/*` (rewritten to the gateway via `next.config.mjs`)
+
+## Dev quickstart
+
+Terminal 1 (daemon):
+```bash
+cargo run
+```
+
+Terminal 2 (gateway):
+```bash
+cargo run --manifest-path gateway/Cargo.toml
+```
+
+Terminal 3 (web UI):
+```bash
+cd web
+cp .env.local.example .env.local   # API_URL can be left at default
+npm i
+npm run dev
+# open http://localhost:3000
+```
+
+## Notes
+- The daemon remains local-only on 127.0.0.1; the gateway defaults to 127.0.0.1:8080.
+- The UI calls `/api/*` which Next rewrites to `${API_URL}/api/*` (default `http://localhost:8080`).
+- You can add a `STATUS` command in the daemon later; the UI already has a hook for `/api/status`.
+
 ## Features
 - Support for playing MP3, FLAC, and whatever else Rodio supports without the Symphonia backend for now
 

--- a/gateway/Cargo.toml
+++ b/gateway/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "grapevine-gateway"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+axum = "0.7"
+tokio = { version = "1", features = ["full"] }
+tower-http = { version = "0.5", features = ["cors", "trace"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+

--- a/gateway/src/main.rs
+++ b/gateway/src/main.rs
@@ -1,0 +1,157 @@
+use axum::{
+    extract::State,
+    http::Method,
+    routing::{get, post},
+    Json, Router,
+};
+use serde::{Deserialize, Serialize};
+use std::io::{Read, Write};
+use std::net::TcpStream;
+use std::time::Duration;
+use std::{env, net::SocketAddr};
+use tower_http::cors::{Any, CorsLayer};
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+enum CommandTypes {
+    Skip,
+    Clear,
+    Pause,
+    Resume,
+    Shutdown,
+    AddQueue,
+    LoopSong,
+    LoopQueue,
+    AddPlaylist,
+    Status, // optional; daemon may respond ERR if unsupported
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+struct Command {
+    command: CommandTypes,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    payload: Option<String>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+struct Response {
+    status: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    errmsg: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    data: Option<serde_json::Value>,
+}
+
+#[derive(Clone)]
+struct AppState {
+    daemon_addr: String,
+}
+
+#[tokio::main]
+async fn main() {
+    // Discover daemon addr: env or scan 6990..7000
+    let daemon_addr = env::var("GRAPEVINED_ADDR")
+        .unwrap_or_else(|_| discover_daemon().unwrap_or_else(|| "127.0.0.1:6990".to_string()));
+
+    let cors = CorsLayer::new()
+        .allow_methods([Method::GET, Method::POST])
+        .allow_origin(Any)
+        .allow_headers(Any);
+
+    let app = Router::new()
+        .route("/api/ping", get(ping))
+        .route("/api/status", get(status))
+        .route("/api/skip", post(skip))
+        .route("/api/clear", post(clear))
+        .route("/api/pause", post(pause))
+        .route("/api/resume", post(resume))
+        .route("/api/shutdown", post(shutdown))
+        .route("/api/loop/song", post(loop_song))
+        .route("/api/loop/queue", post(loop_queue))
+        .route("/api/queue", post(add_queue))
+        .route("/api/playlist", post(add_playlist))
+        .with_state(AppState { daemon_addr })
+        .layer(cors);
+
+    let addr: SocketAddr = "127.0.0.1:8080".parse().unwrap();
+    println!("HTTP gateway on http://{addr}");
+    axum::serve(tokio::net::TcpListener::bind(addr).await.unwrap(), app)
+        .await
+        .unwrap();
+}
+
+async fn ping(State(state): State<AppState>) -> Json<Response> {
+    Json(Response {
+        status: "OK".into(),
+        errmsg: None,
+        data: Some(serde_json::json!({ "daemon": state.daemon_addr })),
+    })
+}
+
+async fn status(State(state): State<AppState>) -> Json<Response> {
+    send_cmd(&state.daemon_addr, Command { command: CommandTypes::Status, payload: None }).await
+}
+async fn skip(State(state): State<AppState>) -> Json<Response> {
+    send_cmd(&state.daemon_addr, Command { command: CommandTypes::Skip, payload: None }).await
+}
+async fn clear(State(state): State<AppState>) -> Json<Response> {
+    send_cmd(&state.daemon_addr, Command { command: CommandTypes::Clear, payload: None }).await
+}
+async fn pause(State(state): State<AppState>) -> Json<Response> {
+    send_cmd(&state.daemon_addr, Command { command: CommandTypes::Pause, payload: None }).await
+}
+async fn resume(State(state): State<AppState>) -> Json<Response> {
+    send_cmd(&state.daemon_addr, Command { command: CommandTypes::Resume, payload: None }).await
+}
+async fn shutdown(State(state): State<AppState>) -> Json<Response> {
+    send_cmd(&state.daemon_addr, Command { command: CommandTypes::Shutdown, payload: None }).await
+}
+async fn loop_song(State(state): State<AppState>) -> Json<Response> {
+    send_cmd(&state.daemon_addr, Command { command: CommandTypes::LoopSong, payload: None }).await
+}
+async fn loop_queue(State(state): State<AppState>) -> Json<Response> {
+    send_cmd(&state.daemon_addr, Command { command: CommandTypes::LoopQueue, payload: None }).await
+}
+
+#[derive(Deserialize)]
+struct PathBody { path: String }
+
+async fn add_queue(State(state): State<AppState>, Json(body): Json<PathBody>) -> Json<Response> {
+    send_cmd(&state.daemon_addr, Command { command: CommandTypes::AddQueue, payload: Some(body.path) }).await
+}
+async fn add_playlist(State(state): State<AppState>, Json(body): Json<PathBody>) -> Json<Response> {
+    send_cmd(&state.daemon_addr, Command { command: CommandTypes::AddPlaylist, payload: Some(body.path) }).await
+}
+
+async fn send_cmd(addr: &str, cmd: Command) -> Json<Response> {
+    let payload = serde_json::to_vec(&cmd).unwrap();
+    let resp = tokio::task::spawn_blocking({
+        let addr = addr.to_string();
+        move || {
+            let mut stream = TcpStream::connect(addr)?;
+            stream.set_read_timeout(Some(Duration::from_secs(3)))?;
+            stream.write_all(&payload)?;
+            let mut buf = Vec::with_capacity(1024);
+            stream.read_to_end(&mut buf)?;
+            let r: Response = serde_json::from_slice(&buf)?;
+            Ok::<_, std::io::Error>(r)
+        }
+    })
+    .await
+    .ok()
+    .and_then(Result::ok)
+    .unwrap_or(Response { status: "ERR".into(), errmsg: Some("gateway failed to reach daemon".into()), data: None });
+
+    Json(resp)
+}
+
+fn discover_daemon() -> Option<String> {
+    for port in 6990..=7000 {
+        let addr = format!("127.0.0.1:{port}");
+        if TcpStream::connect(&addr).is_ok() {
+            return Some(addr);
+        }
+    }
+    None
+}
+

--- a/web/.env.local.example
+++ b/web/.env.local.example
@@ -1,0 +1,3 @@
+# Where the Axum gateway listens
+API_URL=http://localhost:8080
+

--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -1,0 +1,15 @@
+export const metadata = {
+  title: 'Grapevine',
+  description: 'Local audio player UI',
+};
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en">
+      <body style={{ fontFamily: 'system-ui, -apple-system, Segoe UI, Roboto, sans-serif' }}>
+        {children}
+      </body>
+    </html>
+  );
+}
+

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -1,0 +1,42 @@
+'use client';
+import { useEffect, useState } from 'react';
+import { api, GrapeResponse } from '@/lib/api';
+import { Controls } from '@/components/Controls';
+
+export default function Page() {
+  const [daemon, setDaemon] = useState<string>('—');
+  const [path, setPath] = useState('');
+  const [msg, setMsg] = useState<string>('');
+
+  useEffect(() => {
+    api.ping().then(r => setDaemon((r.data as any)?.daemon ?? 'unknown')).catch(() => setDaemon('unreachable'));
+  }, []);
+
+  async function handle(res: Promise<GrapeResponse>) {
+    const r = await res;
+    setMsg(r.status === 'OK' ? 'OK' : (r.errmsg ?? 'ERR'));
+    setTimeout(() => setMsg(''), 1500);
+  }
+
+  return (
+    <main style={{ padding: 24, maxWidth: 720, margin: '0 auto' }}>
+      <h1 style={{ marginBottom: 4 }}>Grapevine</h1>
+      <p style={{ opacity: 0.7, marginBottom: 16 }}>Daemon: {daemon}</p>
+
+      <div style={{ display: 'flex', gap: 8, marginBottom: 16 }}>
+        <input
+          placeholder="Absolute path to song or .m3u"
+          value={path}
+          onChange={e => setPath(e.target.value)}
+          style={{ flex: 1, padding: 8, border: '1px solid #ddd', borderRadius: 8 }}
+        />
+        <button onClick={() => handle(api.addQueue(path))} disabled={!path}>Add Song</button>
+        <button onClick={() => handle(api.addPlaylist(path))} disabled={!path}>Add Playlist</button>
+      </div>
+
+      <Controls onAction={p => handle(p)} />
+      {!!msg && <div style={{ marginTop: 16, opacity: 0.9 }}>{msg}</div>}
+    </main>
+  );
+}
+

--- a/web/components/Controls.tsx
+++ b/web/components/Controls.tsx
@@ -1,0 +1,23 @@
+'use client';
+import { api, GrapeResponse } from '@/lib/api';
+
+export function Controls({ onAction }: { onAction: (p: Promise<GrapeResponse>) => void }) {
+  const Btn = (props: React.ButtonHTMLAttributes<HTMLButtonElement>) => (
+    <button {...props} style={{ padding: 10, borderRadius: 8, border: '1px solid #ddd' }} />
+  );
+  const Grid = (props: React.HTMLAttributes<HTMLDivElement>) => (
+    <div {...props} style={{ display: 'grid', gap: 10, gridTemplateColumns: 'repeat(3, minmax(0,1fr))' }} />
+  );
+  return (
+    <Grid>
+      <Btn onClick={() => onAction(api.skip())}>Skip</Btn>
+      <Btn onClick={() => onAction(api.pause())}>Pause</Btn>
+      <Btn onClick={() => onAction(api.resume())}>Resume</Btn>
+      <Btn onClick={() => onAction(api.clear())}>Clear</Btn>
+      <Btn onClick={() => onAction(api.loopSong())}>Loop Song</Btn>
+      <Btn onClick={() => onAction(api.loopQueue())}>Loop Queue</Btn>
+      <Btn onClick={() => onAction(api.shutdown())}>Shutdown</Btn>
+    </Grid>
+  );
+}
+

--- a/web/lib/api.ts
+++ b/web/lib/api.ts
@@ -1,0 +1,30 @@
+export type GrapeResponse = {
+  status: 'OK' | 'ERR';
+  errmsg?: string;
+  data?: unknown;
+}
+
+async function post(path: string, body?: unknown): Promise<GrapeResponse> {
+  const res = await fetch(`/api${path}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: body ? JSON.stringify(body) : undefined,
+  });
+  if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
+  return res.json();
+}
+
+export const api = {
+  ping: () => fetch('/api/ping').then(r => r.json()),
+  status: () => fetch('/api/status').then(r => r.json()),
+  skip: () => post('/skip'),
+  pause: () => post('/pause'),
+  resume: () => post('/resume'),
+  clear: () => post('/clear'),
+  loopSong: () => post('/loop/song'),
+  loopQueue: () => post('/loop/queue'),
+  addQueue: (path: string) => post('/queue', { path }),
+  addPlaylist: (path: string) => post('/playlist', { path }),
+  shutdown: () => post('/shutdown'),
+};
+

--- a/web/next.config.mjs
+++ b/web/next.config.mjs
@@ -1,0 +1,16 @@
+/** @type {import('next').NextConfig} */
+const API_URL = process.env.API_URL ?? 'http://localhost:8080';
+
+const nextConfig = {
+  async rewrites() {
+    return [
+      {
+        source: '/api/:path*',
+        destination: `${API_URL}/api/:path*`,
+      },
+    ];
+  },
+};
+
+export default nextConfig;
+

--- a/web/package.json
+++ b/web/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "grapevine-web",
+  "private": true,
+  "version": "0.1.0",
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "next": "14.2.5",
+    "react": "18.3.1",
+    "react-dom": "18.3.1"
+  },
+  "devDependencies": {
+    "@types/node": "^20.14.9",
+    "@types/react": "^18.3.3",
+    "@types/react-dom": "^18.3.0",
+    "typescript": "^5.5.3",
+    "eslint": "^9.7.0",
+    "eslint-config-next": "14.2.5"
+  }
+}
+

--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}
+


### PR DESCRIPTION
## Summary
- add Axum-based HTTP gateway that proxies JSON commands to the TCP daemon
- scaffold Next.js 14 UI with basic controls and API helpers
- document new web UI and gateway usage in README

## Testing
- `cargo test` *(fails: The system library `alsa` required by crate `alsa-sys` was not found)*
- `cargo test --manifest-path gateway/Cargo.toml`
- `npm test --prefix web` *(fails: Missing script: "test"*)


------
https://chatgpt.com/codex/tasks/task_e_68955176aee88332bf7c9934209bd5cc